### PR TITLE
Update MAX_TX_FEE to 1 DCR, which aligns with current max txsize 100Kb

### DIFF
--- a/lib/common/defaults.js
+++ b/lib/common/defaults.js
@@ -5,7 +5,7 @@ var Defaults = {};
 Defaults.MIN_FEE_PER_KB = 0;
 Defaults.MAX_FEE_PER_KB = 1000000;
 Defaults.MIN_TX_FEE = 0;
-Defaults.MAX_TX_FEE = 0.1 * 1e8;
+Defaults.MAX_TX_FEE = 1 * 1e8;
 Defaults.MAX_TX_SIZE_IN_KB = 100;
 
 Defaults.MAX_KEYS = 100;


### PR DESCRIPTION
This fixes an error we encountered this morning, stemming from allowing tx sizes well above the max allowed tx fee.  Now these are roughly equal with 100Kb tx size enforcement.  

Tested with 2of3 and 1of1 testnet transactions.
