### PR TITLE
if feePerKb is not specified, use MIN_FEE_PER_KB

### DIFF
--- a/lib/common/defaults.js
+++ b/lib/common/defaults.js
@@ -2,8 +2,8 @@
 
 var Defaults = {};
 
-Defaults.MIN_FEE_PER_KB = 0;
-Defaults.MAX_FEE_PER_KB = 1000000;
+Defaults.MIN_FEE_PER_KB = 1 * 1e6;
+Defaults.MAX_FEE_PER_KB = 1 * 1e7;
 Defaults.MIN_TX_FEE = 0;
 Defaults.MAX_TX_FEE = 1 * 1e8;
 Defaults.MAX_TX_SIZE_IN_KB = 100;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1867,8 +1867,10 @@ WalletService.prototype._validateAndSanitizeTxOpts = function(wallet, opts, cb) 
     },
     function(next) {
       // feePerKb is required unless inputs & fee are specified
+      // if not specified, use Defaults.MIN_FEE_PER_KB
       if (!_.isNumber(opts.feePerKb) && !(opts.inputs && _.isNumber(opts.fee)))
-        return next(new ClientError('Required argument missing'));
+          opts.feePerKb = Defaults.MIN_FEE_PER_KB;
+//        return next(new ClientError('Required argument missing'));
 
       if (_.isNumber(opts.feePerKb)) {
         if (opts.feePerKb < Defaults.MIN_FEE_PER_KB || opts.feePerKb > Defaults.MAX_FEE_PER_KB)


### PR DESCRIPTION
Copay doesn't send `feePerKb` parameter when the user doesn't select a value in the UI.  