### PR TITLE
CoinmarketCap fiatRateService

### DIFF
--- a/config.js
+++ b/config.js
@@ -56,8 +56,8 @@ var config = {
     pushServerUrl: 'http://localhost:8000',
   },
   fiatRateServiceOpts: {
-    defaultProvider: 'BitPay',
-    fetchInterval: 60, // in minutes
+    defaultProvider: 'coinmarketcap',
+    fetchInterval: 15, // in minutes
   },
   // To use email notifications uncomment this:
   // emailOpts: {

--- a/lib/common/defaults.js
+++ b/lib/common/defaults.js
@@ -47,7 +47,7 @@ Defaults.DEFAULT_FEE_PER_KB = Defaults.FEE_LEVELS[1].defaultValue;
 // Minimum nb of addresses a wallet must have to start using 2-step balance optimization
 Defaults.TWO_STEP_BALANCE_THRESHOLD = 100;
 
-Defaults.FIAT_RATE_PROVIDER = 'BitPay';
+Defaults.FIAT_RATE_PROVIDER = 'coinmarketcap';
 Defaults.FIAT_RATE_FETCH_INTERVAL = 10; // In minutes
 Defaults.FIAT_RATE_MAX_LOOK_BACK_TIME = 120; // In minutes
 

--- a/lib/expressapp.js
+++ b/lib/expressapp.js
@@ -550,17 +550,17 @@ ExpressApp.prototype.start = function(opts, cb) {
   });
 
   router.get('/v1/fiatrates/:code/', function(req, res) {
-    getServerWithAuth(req, res, function(server) {
+    var server = getServer(req, res);
+
       var opts = {
         code: req.params['code'],
         source: req.query.source,
-        ts: +req.query.ts,
+        ts: Date.now(),
       };
       server.getFiatRate(opts, function(err, rates) {
         if (err) return returnError(err, res, req);
         res.json(rates);
       });
-    });
   });
 
   router.post('/v1/pushnotifications/subscriptions/', function(req, res) {

--- a/lib/fiatrateproviders/coinmarketcap.js
+++ b/lib/fiatrateproviders/coinmarketcap.js
@@ -1,0 +1,20 @@
+var _ = require('lodash');
+
+var FIAT_SYMBOL = 'USD';
+
+var provider = {
+  name: 'coinmarketcap',
+  url: 'https://api.coinmarketcap.com/v1/ticker/decred/?convert=' + FIAT_SYMBOL,
+  parseFn: function(raw) {
+    var rates = _.compact(_.map(raw, function(d) {
+      if (!d.price_usd) return null;
+      return {
+        code: FIAT_SYMBOL,
+        value: d.price_usd,
+      };
+    }));
+    return rates;
+  },
+};
+
+module.exports = provider;

--- a/lib/fiatrateproviders/index.js
+++ b/lib/fiatrateproviders/index.js
@@ -1,6 +1,7 @@
 var Providers = {
-  BitPay: require('./bitpay'),
-  Bitstamp: require('./bitstamp'),
+  // BitPay: require('./bitpay'),
+  // Bitstamp: require('./bitstamp'),
+  coinmarketcap: require('./coinmarketcap')
 }
 
 module.exports = Providers;

--- a/lib/fiatrateservice.js
+++ b/lib/fiatrateservice.js
@@ -121,11 +121,13 @@ FiatRateService.prototype.getRate = function(opts, cb) {
       if (err) return cb(err);
       if (rate && (ts - rate.ts) > Defaults.FIAT_RATE_MAX_LOOK_BACK_TIME * 60 * 1000) rate = null;
 
-      return cb(null, {
+      return cb(null, [{
         ts: +ts,
         rate: rate ? rate.value : undefined,
         fetchedOn: rate ? rate.ts : undefined,
-      });
+        code: opts.code,
+        name: opts.code
+      }]);
     });
   }, function(err, res) {
     if (err) return cb(err);


### PR DESCRIPTION
Added `FiatRateProvider` that fetches USD exchange rate from CoinmarketCap API

Updated the BWC API endpoint as Copay now expects a slightly different interface.